### PR TITLE
Feature page content without summary

### DIFF
--- a/blueprints/item.yaml
+++ b/blueprints/item.yaml
@@ -11,6 +11,18 @@ form:
           type: tab
           title: ADMIN.RECIPE
           fields:
+            header.page_content_without_summary:
+              name: page_content_without_summary
+              label: ADMIN.PAGE_CONTENT_WITHOUT_SUMMARY
+              type: toggle
+              highlight: 1
+              default: false
+              options:
+                true: ADMIN.YES
+                false: ADMIN.NO
+              validate:
+                type: boolean
+
             Description:
               type: section
               title: ADMIN.DESCRIPTION

--- a/blueprints/item.yaml
+++ b/blueprints/item.yaml
@@ -18,8 +18,8 @@ form:
               highlight: 1
               default: false
               options:
-                true: ADMIN.YES
-                false: ADMIN.NO
+                true: 'YES'
+                false: 'NO'
               validate:
                 type: boolean
 

--- a/languages.yaml
+++ b/languages.yaml
@@ -4,6 +4,7 @@ en:
     DESCRIPTION: Blogging about stuff
     COPYRIGHT: © Copyright %s Your Company
   ADMIN:
+    PAGE_CONTENT_WITHOUT_SUMMARY: Display page content without summary
     RECIPE: Recipe
     DESCRIPTION: Description
     DESCRIPTION_LABEL: Advanced recipe description

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -22,7 +22,7 @@
 
         <div id="posts" class="posts posts-list clearfix">
           {% for child in collection %}
-            {% include 'partials/blog_item.html.twig' with {'page':child, 'truncate':true} %}
+            {% include 'partials/blog_item.html.twig' with {'page':child, 'display_full_mode':false} %}
           {% endfor %}
         </div>
 

--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -14,6 +14,10 @@
 {% endif  %}
 
 {% block content %}
-  {% include 'partials/blog_item.html.twig' with {'truncate':false,'big_header':true} %}
+  {# 0x01af/2024-04-21:
+  - issue: variable 'truncate' doesn't follow coding-best-practice 'don't call a variable like a given function'
+  - solution: change variable 'truncate' to 'display_mode_full'
+  #}
+  {% include 'partials/blog_item.html.twig' with {'display_mode_full':true,'big_header':true} %}
 {% endblock %}
 {% endembed %}

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -1,8 +1,8 @@
-{% set _page_content = page.summary|raw %}
+{% set _page_content = page.summary %}
 {% if display_mode_full and page.header.page_content_without_summary %}
   {% set _page_content = page.content|slice(page.summary|length) %}
 {% elseif display_mode_full %}
-  {% set _page_content = page.content|raw %}
+  {% set _page_content = page.content %}
 {% elseif not display_mode_full and site.summary.striptags == true and page.summary != page.content %}
   {% set _page_content =  page.summary|striptags %}
 {% endif %}
@@ -147,7 +147,7 @@
         {% endif %}
         <div class="clear"></div>
 
-        {{ _page_content }}
+        {{ _page_content|raw }}
         
         {% if page.header.continue_link is not same as(false) %}
         {% if not display_mode_full and page.summary != page.content %}

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -1,26 +1,11 @@
-{% set _page_content = page.content|raw %}
+{% set _page_content = page.summary|raw %}
 {% if display_mode_full and page.header.page_content_without_summary %}
   {% set _page_content = page.content|slice(page.summary|length) %}
 {% elseif display_mode_full %}
-{% 
+  {% {% set _page_content = page.content|raw %}
+{% elseif not display_mode_full and site.summary.striptags == true and page.summary != page.content %}
+  {% set _page_content =  page.summary|striptags %}
 {% endif %}
-{# Theme: Default truncate content to 550 characters #}
-
-{% if display_mode_full and page.header.continue_link is same as(false) %}
-  {% set show_prev_next = true %}
-{% else %}
-  {% set show_prev_next = true %}
-{% endif %}
-
-{% elseif not display_mode_full and page.summary != page.content %}
-  {% if site.summary.striptags == true %}
-    {% set _page_content =  page.summary|striptags %}
-  {% else %}
-    {% set _page_content = page.summary|raw %}
-  {% endif %}
-
-  
-
 
 <article id="post-{{ loop.index }}" class="post-{{ loop.index }} post type-post status-publish format-standard has-post-thumbnail hentry category-cakes tag-no-excerpt">
 

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -2,7 +2,7 @@
 {% if display_mode_full and page.header.page_content_without_summary %}
   {% set _page_content = page.content|slice(page.summary|length) %}
 {% elseif display_mode_full %}
-  {% {% set _page_content = page.content|raw %}
+  {% set _page_content = page.content|raw %}
 {% elseif not display_mode_full and site.summary.striptags == true and page.summary != page.content %}
   {% set _page_content =  page.summary|striptags %}
 {% endif %}
@@ -146,7 +146,8 @@
         {% endif %}
         {% endif %}
         <div class="clear"></div>
-        {{ _page_content|raw }}
+
+        {{ _page_content }}
         
         {% if page.header.continue_link is not same as(false) %}
         {% if not display_mode_full and page.summary != page.content %}

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -1,3 +1,27 @@
+{% set _page_content = page.content|raw %}
+{% if display_mode_full and page.header.page_content_without_summary %}
+  {% set _page_content = page.content|slice(page.summary|length) %}
+{% elseif display_mode_full %}
+{% 
+{% endif %}
+{# Theme: Default truncate content to 550 characters #}
+
+{% if display_mode_full and page.header.continue_link is same as(false) %}
+  {% set show_prev_next = true %}
+{% else %}
+  {% set show_prev_next = true %}
+{% endif %}
+
+{% elseif not display_mode_full and page.summary != page.content %}
+  {% if site.summary.striptags == true %}
+    {% set _page_content =  page.summary|striptags %}
+  {% else %}
+    {% set _page_content = page.summary|raw %}
+  {% endif %}
+
+  
+
+
 <article id="post-{{ loop.index }}" class="post-{{ loop.index }} post type-post status-publish format-standard has-post-thumbnail hentry category-cakes tag-no-excerpt">
 
   <div class="entry-media {% if not display_mode_full %}entry-{% if page.header.youtube or page.header.soundcloud or page.header.vimeo %}video{% else %}image{% endif %}{% else %} resp_video{% endif %}">
@@ -86,7 +110,8 @@
         {% if page.header.youtube or page.header.vimeo or page.header.soundcloud %}
         <div class="fit-vids-style">
         <style>
-        .fluid-width-video-wrapper {width: 100%;position: relative;padding: 0;}                                                                                   .fluid-width-video-wrapper iframe, .fluid-width-video-wrapper object, .fluid-width-video-wrapper embed { position: absolute; top: 0;                                  left: 0; width: 100%; height: 100%;}
+        .fluid-width-video-wrapper {width: 100%;position: relative;padding: 0;}
+        .fluid-width-video-wrapper iframe, .fluid-width-video-wrapper object, .fluid-width-video-wrapper embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%;}
         </style>
         </div>
 
@@ -136,25 +161,8 @@
         {% endif %}
         {% endif %}
         <div class="clear"></div>
-
-        {% if page.header.continue_link is same as(false) %}
-          {{ page.content|raw }}
-        {% if display_mode_full %}
-          {% set show_prev_next = true %}
-        {% endif %}
-        {% elseif not display_mode_full and page.summary != page.content %}
-          {% if site.summary.striptags == true %}
-            {{ page.summary|striptags }}
-          {% else %}
-            {{ page.summary|raw }}
-          {% endif %}
-        {% elseif not display_mode_full %}
-          {{ page.content|truncate(550) }}
-        {% else %}
-          {{ page.content|raw }}
-          {% set show_prev_next = true %}
-        {% endif %}
-
+        {{ _page_content|raw }}
+        
         {% if page.header.continue_link is not same as(false) %}
         {% if not display_mode_full and page.summary != page.content %}
         <div class="link-more"><a href="{{ page.url }}">{{ 'READ_MORE'|t }}</a></div>

--- a/templates/partials/blog_item.html.twig
+++ b/templates/partials/blog_item.html.twig
@@ -1,6 +1,6 @@
 <article id="post-{{ loop.index }}" class="post-{{ loop.index }} post type-post status-publish format-standard has-post-thumbnail hentry category-cakes tag-no-excerpt">
 
-  <div class="entry-media {% if truncate %}entry-{% if page.header.youtube or page.header.soundcloud or page.header.vimeo %}video{% else %}image{% endif %}{% else %} resp_video{% endif %}">
+  <div class="entry-media {% if not display_mode_full %}entry-{% if page.header.youtube or page.header.soundcloud or page.header.vimeo %}video{% else %}image{% endif %}{% else %} resp_video{% endif %}">
     <figure class="post-thumbnail">
       {% if page.media.images|first %}
       {{ page.media.images|first.cropZoom(338,451).html('','', 'attachment-receptar-featured size-receptar-featured wp-post-image')|raw }}
@@ -11,7 +11,7 @@
   </div>
 
   <div class="entry-inner">
-    <div class="entry-inner{% if truncate %}-content{% endif %}">
+    <div class="entry-inner{% if not display_mode_full %}-content{% endif %}">
 
       <header class="entry-header">
         {% if page.header.link %}
@@ -24,7 +24,7 @@
         {% else %}
         <h1 class="entry-title"><a href="{{ page.url }}">{{ page.title }}</a></h1>
         {% endif %}
-        {% if not truncate %}
+        {% if display_mode_full %}
         <div class="entry-category">
           {% if page.taxonomy.category %}
           <span class="cat-links entry-meta-element">
@@ -37,7 +37,7 @@
         {% endif %}
       </header>
 
-      {% if not truncate %}
+      {% if display_mode_full %}
       <div class="entry-meta entry-meta-bottom">
         <time datetime="{{ 'MONTHS_OF_THE_YEAR'|ta(post.date|date('n') - 1) }} {{ page.date|date("d, Y") }}" class="entry-date entry-meta-element published" title="{{ 'MONTHS_OF_THE_YEAR'|ta(post.date|date('n') - 1) }} {{ page.date|date("d, Y") }}" itemprop="datePublished">{{ 'MONTHS_OF_THE_YEAR'|ta(post.date|date('n') - 1) }} {{ page.date|date("d, Y") }}</time>
 
@@ -71,7 +71,7 @@
 
       <div class="entry-content">
 
-        {% if not truncate %}
+        {% if display_mode_full %}
         {% if page.header.description %}
         <div class="fl-module fl-module-rich-text text-center" style="margin-bottom: 6%;">
           <p>
@@ -139,16 +139,16 @@
 
         {% if page.header.continue_link is same as(false) %}
           {{ page.content|raw }}
-        {% if not truncate %}
+        {% if display_mode_full %}
           {% set show_prev_next = true %}
         {% endif %}
-        {% elseif truncate and page.summary != page.content %}
+        {% elseif not display_mode_full and page.summary != page.content %}
           {% if site.summary.striptags == true %}
             {{ page.summary|striptags }}
           {% else %}
             {{ page.summary|raw }}
           {% endif %}
-        {% elseif truncate %}
+        {% elseif not display_mode_full %}
           {{ page.content|truncate(550) }}
         {% else %}
           {{ page.content|raw }}
@@ -156,14 +156,14 @@
         {% endif %}
 
         {% if page.header.continue_link is not same as(false) %}
-        {% if truncate and page.summary != page.content %}
+        {% if not display_mode_full and page.summary != page.content %}
         <div class="link-more"><a href="{{ page.url }}">{{ 'READ_MORE'|t }}</a></div>
-        {% elseif truncate %}
+        {% elseif not display_mode_full %}
         <div class="link-more"><a href="{{ page.url }}">{{ 'READ_MORE'|t }}</a></div>
         {% endif %}
         {% endif %}
 
-        {% if not truncate %}
+        {% if display_mode_full %}
         <div class="sharedaddy sd-sharing-enabled">
           <div class="robots-nocontent sd-block sd-social sd-social-icon-text sd-sharing">
             <h3 class="sd-title">{{ 'SHARE'|t }}</h3>
@@ -195,7 +195,7 @@
         {% endif %}
       </div>
 
-      {% if not truncate %}
+      {% if display_mode_full %}
       <div id="jp-relatedposts" class="jp-relatedposts" style="display: block;">
         <h3 class="jp-relatedposts-headline"><em>{{ 'RELATED_POSTS'|t }}</em></h3>
         <div class="jp-relatedposts-items jp-relatedposts-items-visual">
@@ -205,7 +205,7 @@
       <hr/>
       {% endif %}
 
-      {% if not truncate %}
+      {% if display_mode_full %}
       {% if config.plugins.jscomments.enabled and config.plugins.jscomments.provider %}
       <div class="comments-area-wrapper">
         <div class="comments-area">


### PR DESCRIPTION
- feat: Add configurable option for displaying page content without summary
- issue: variable 'truncate' doesn't follow coding-best-practice 'don't call a variable like a given function' -> solution: change variable 'truncate' to 'display_mode_full